### PR TITLE
ENV: inline environment variables specified in command line override the .env values.

### DIFF
--- a/mnist.py
+++ b/mnist.py
@@ -31,7 +31,7 @@ import wandb
 ############################ CONFIG ########################
 
 from dotenv import dotenv_values
-config = dotenv_values(".env")
+config = { **dotenv_values(".env"), **os.environ }
 
 LOG_NAME = config.get("LOG_NAME", "MNIST")
 TIMEZONE = config.get("TIMEZONE", "UTC")


### PR DESCRIPTION
Usage example: `NET_ARCHITECTURE="[1500, 1500, 1500]" uv run mnist.py`